### PR TITLE
Elaborate on scope documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,13 @@ Or install it yourself as:
 
 ## Custom scopes
 
+By default, the `api` scope is requested and must be allowed in GitLab's application configuration. To use different scopes:
+
     use OmniAuth::Builder do
       provider :gitlab, ENV['GITLAB_KEY'], ENV['GITLAB_SECRET'], scope: 'read_user openid'
     end
+
+Requesting a scope that is not configured will result the error "The requested scope is invalid, unknown, or malformed.".
 
 ## Old API version
 


### PR DESCRIPTION
- Specify the default scope used
- Mention that the scope on the GitLab application must match and note what happens if it doesn't.