### PR TITLE
Fixes gitlab oauth login

### DIFF
--- a/lib/omniauth/strategies/gitlab.rb
+++ b/lib/omniauth/strategies/gitlab.rb
@@ -4,7 +4,7 @@ require 'omniauth-oauth2'
 module OmniAuth
   module Strategies
     class GitLab < OmniAuth::Strategies::OAuth2
-      option :client_options, site: 'https://gitlab.com/api/v4'
+      option :client_options, site: 'https://gitlab.com'
 
       option :redirect_url
 
@@ -24,7 +24,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('user').parsed
+        @raw_info ||= access_token.get('api/v4/user').parsed
       end
 
       private

--- a/spec/omniauth/strategies/gitlab_spec.rb
+++ b/spec/omniauth/strategies/gitlab_spec.rb
@@ -27,7 +27,7 @@ describe OmniAuth::Strategies::GitLab do
     context 'with defaults' do
       subject { gitlab_service.options.client_options }
 
-      its(:site) { is_expected.to eq 'https://gitlab.com/api/v4' }
+      its(:site) { is_expected.to eq 'https://gitlab.com' }
     end
 
     context 'with override' do
@@ -51,7 +51,7 @@ describe OmniAuth::Strategies::GitLab do
 
   describe '#raw_info' do
     it 'sent request to current user endpoint' do
-      expect(access_token).to receive(:get).with('user').and_return(response)
+      expect(access_token).to receive(:get).with('api/v4/user').and_return(response)
       expect(subject.raw_info).to eq(parsed_response)
     end
   end


### PR DESCRIPTION
This gem is not working with latest gitlab. Issue is that oauth urls were moved out of `api/v4`, while the get user api stayed there. This PR fixes that. 