### PR TITLE
Drop /api/v4 suffix from site parameter documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Or install it yourself as:
       provider :gitlab, ENV['GITLAB_KEY'], ENV['GITLAB_SECRET'],
         {
            client_options: {
-             site: 'https://gitlab.YOURDOMAIN.com/api/v4'
+             site: 'https://gitlab.YOURDOMAIN.com'
            }
         }
     end

--- a/spec/omniauth/strategies/gitlab_spec.rb
+++ b/spec/omniauth/strategies/gitlab_spec.rb
@@ -5,7 +5,7 @@ describe OmniAuth::Strategies::GitLab do
   let(:parsed_response) { double('ParsedResponse') }
   let(:response) { double('Response', parsed: parsed_response) }
 
-  let(:enterprise_site) { 'https://some.other.site.com/api/v3' }
+  let(:enterprise_site) { 'https://some.other.site.com' }
 
   let(:gitlab_service) { OmniAuth::Strategies::GitLab.new({}) }
   let(:enterprise) do


### PR DESCRIPTION
Due to the change in https://github.com/oauth-xx/oauth2/pull/469 to fix relative URLs, https://github.com/linchus/omniauth-gitlab/pull/22 was updated to drop the `api/v4` suffix from the `site` parameter. This was needed since `oauth/authorize` is the new default parameter, and omitting a leading slash makes a big difference.

Current:

```ruby
Faraday.new('https://gitlab.example.com').build_url('oauth/authorize').to_s
=> "https://gitlab.example.com/oauth/authorize"
```

However, if you leave the `api/v4` suffix, you get the wrong URL:

```ruby
Faraday.new('https://gitlab.example.com/api/v4').build_url('oauth/authorize').to_s
=> "https://gitlab.example.com/api/v4/oauth/authorize"
```

Notice a leading slash also works:

```ruby
Faraday.new('https://gitlab.example.com/api/v4').build_url('/oauth/authorize').to_s
=> "https://gitlab.example.com/oauth/authorize"
```